### PR TITLE
Fix unstable keepalive_input_message ut

### DIFF
--- a/test/brpc_builtin_service_unittest.cpp
+++ b/test/brpc_builtin_service_unittest.cpp
@@ -841,8 +841,10 @@ void* dummy_bthread(void*) {
 
 
 #ifdef BRPC_BTHREAD_TRACER
+bool g_bthread_trace_start = false;
 bool g_bthread_trace_stop = false;
 void* bthread_trace(void*) {
+    g_bthread_trace_start = true;
     while (!g_bthread_trace_stop) {
         bthread_usleep(1000 * 100);
     }
@@ -886,6 +888,9 @@ TEST_F(BuiltinServiceTest, bthreads) {
     {
         bthread_t th;
         EXPECT_EQ(0, bthread_start_background(&th, NULL, bthread_trace, NULL));
+        while (!g_bthread_trace_start) {
+            bthread_usleep(1000 * 10);
+        }
         ClosureChecker done;
         brpc::Controller cntl;
         std::string id_string;


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number:

Problem Summary:

linux下，epoll监听未建连的socket fd，会立即触发读事件，读失败会将Socket SetFailed，导致SocketTest.keepalive_input_message UT中Address刚创建好的Socket失败。

https://github.com/apache/brpc/actions/runs/14082862048/job/39439643977

```shell
W0326 13:55:34.389770 41262 25769804351 src/brpc/input_messenger.cpp:387] Fail to read from Socket{id=11 fd=14 addr=0.0.0.0:0} (0xdb9be40): Transport endpoint is not connected
```

### What is changed and the side effects?

Changed:

Side effects:
- Performance effects(性能影响):

- Breaking backward compatibility(向后兼容性): 

---
### Check List:
- Please make sure your changes are compilable(请确保你的更改可以通过编译).
- When providing us with a new feature, it is best to add related tests(如果你向我们增加一个新的功能, 请添加相关测试).
- Please follow [Contributor Covenant Code of Conduct](https://github.com/apache/brpc/blob/master/CODE_OF_CONDUCT.md).(请遵循贡献者准则).
